### PR TITLE
Fix code scanning alert no. 83: Missing rate limiting

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -26,6 +26,7 @@ import path from 'path'
 import morgan from 'morgan'
 import colors from 'colors/safe'
 import * as utils from './lib/utils'
+import rateLimit from 'express-rate-limit';
 
 const startTime = Date.now()
 const finale = require('finale-rest')
@@ -625,7 +626,11 @@ restoreOverwrittenFilesWithOriginals().then(() => {
   app.get('/snippets/:challenge', vulnCodeSnippet.serveCodeSnippet())
   app.post('/snippets/verdict', vulnCodeSnippet.checkVulnLines())
   app.get('/snippets/fixes/:key', vulnCodeFixes.serveCodeFixes())
-  app.post('/snippets/fixes', vulnCodeFixes.checkCorrectFix())
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+  app.post('/snippets/fixes', limiter, vulnCodeFixes.checkCorrectFix())
 
   app.use(angular())
 


### PR DESCRIPTION
Fixes [https://github.com/tdupoiron-org/demo-ghas/security/code-scanning/83](https://github.com/tdupoiron-org/demo-ghas/security/code-scanning/83)

To fix the problem, we need to introduce rate limiting to the route handler `vulnCodeFixes.checkCorrectFix()`. The best way to do this is by using the `express-rate-limit` package, which is a well-known middleware for rate limiting in Express applications. We will set up a rate limiter and apply it to the specific route handler.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `server.ts` file.
3. Configure the rate limiter with appropriate settings (e.g., maximum number of requests per minute).
4. Apply the rate limiter to the `vulnCodeFixes.checkCorrectFix()` route handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
